### PR TITLE
Remove unnecessary alias

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -25,10 +25,6 @@ const config = {
         };
       }
     }
-    
-    // Install webpack aliases:
-    const aliases = config.resolve.alias || (config.resolve.alias = {});
-    aliases.react = aliases['react-dom'] = 'preact/compat';
 
     // inject Preact DevTools
     if (dev && !isServer) {


### PR DESCRIPTION
Given the `package.json` trick that uses `preact-compat/react-dom` this alias isn't required.