### PR TITLE
Remove experimental.polyfillsOptimization flag

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,6 @@ const preact = require('preact');
 const config = {
   experimental: {
     modern: true,
-    polyfillsOptimization: true
   },
 
   webpack(config, { dev, isServer }) {


### PR DESCRIPTION
The `experimental.polyfillsOptimization` flag has been removed with [this PR](https://github.com/vercel/next.js/pull/10574), which was shipped with Next.js v9.3.0 release. (https://github.com/vercel/next.js/releases/tag/v9.3.0)